### PR TITLE
Added schemas and fix validation error in SecuritySchemes

### DIFF
--- a/src/main/kotlin/cc/vileda/openapi/dsl/OpenApiDsl.kt
+++ b/src/main/kotlin/cc/vileda/openapi/dsl/OpenApiDsl.kt
@@ -18,7 +18,11 @@ import io.swagger.v3.oas.models.servers.ServerVariables
 import io.swagger.v3.oas.models.tags.Tag
 import org.json.JSONObject
 import java.io.File
+import java.math.BigDecimal
 import java.nio.file.Files
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.Date
 
 fun openapiDsl(init: OpenAPI.() -> Unit): OpenAPI {
     val openapi3 = OpenAPI()
@@ -135,7 +139,9 @@ fun Components.securityScheme(init: SecurityScheme.() -> Unit) {
     if (securitySchemes == null) {
         securitySchemes = mutableMapOf()
     }
-    securitySchemes.put(security.name, security)
+    // Security schemes will not validate with a name value. Use https://editor.swagger.io to validate.
+    // Use the type as the name. see https://swagger.io/docs/specification/authentication/
+    securitySchemes.put(security.type.toString(), security)
 }
 
 fun SecurityScheme.flows(init: OAuthFlows.() -> Unit) {
@@ -373,15 +379,30 @@ inline fun <reified T> Content.mediaTypeArrayOf(name: String) {
 }
 
 inline fun <reified T> findSchema(): Schema<*>? {
-    return when (T::class) {
+    return getEnumSchema<T>() ?: when (T::class) {
         String::class -> StringSchema()
         Boolean::class -> BooleanSchema()
         java.lang.Boolean::class -> BooleanSchema()
         Int::class -> IntegerSchema()
         Integer::class -> IntegerSchema()
         List::class -> ArraySchema()
+        Long::class -> IntegerSchema().format("int64")
+        BigDecimal::class -> IntegerSchema().format("")
+        Date::class -> DateSchema()
+        LocalDate::class -> DateSchema()
+        LocalDateTime::class -> DateTimeSchema()
         else -> ModelConverters.getInstance().read(T::class.java)[T::class.java.simpleName]
     }
+}
+
+inline fun <reified T> getEnumSchema(): Schema<*>? {
+    val values = T::class.java.enumConstants ?: return null
+
+    val schema = StringSchema()
+    for (enumVal in values) {
+        schema.addEnumItem(enumVal.toString())
+    }
+    return schema
 }
 
 fun MediaType.extension(name: String, value: Any) {

--- a/src/test/kotlin/cc/vileda/openapi/dsl/OpenApiDslTest.kt
+++ b/src/test/kotlin/cc/vileda/openapi/dsl/OpenApiDslTest.kt
@@ -8,12 +8,18 @@ import io.swagger.v3.oas.models.PathItem
 import io.swagger.v3.oas.models.media.*
 import io.swagger.v3.oas.models.parameters.Parameter
 import io.swagger.v3.oas.models.security.SecurityScheme
+import java.math.BigDecimal
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
 
 
 data class ExampleSchema(val foo: String)
 data class AnotherExampleSchema(val bar: String)
 data class ExampleRequestSchema(val foo: String)
 data class ListExampleSchema(val baz : List<ExampleSchema>)
+
+enum class ExampleEnum {ONE, TWO}
 
 class OpenApi3BuilderTest : StringSpec() {
     init {
@@ -45,8 +51,8 @@ class OpenApi3BuilderTest : StringSpec() {
                 schema<ExampleRequestSchema>()
                 schema<AnotherExampleSchema>()
                 schema<ListExampleSchema>()
+                schema<ExampleEnum>()
                 securityScheme {
-                    name = "foo"
                     type = SecurityScheme.Type.OPENIDCONNECT
                     openIdConnectUrl = "http://localhost/auth"
                     flows {
@@ -64,7 +70,7 @@ class OpenApi3BuilderTest : StringSpec() {
                 }
             }
             security {
-                put("foo", listOf("bar"))
+                put(SecurityScheme.Type.OPENIDCONNECT.toString(), listOf("bar"))
             }
             info {
                 title = "jjjj"
@@ -147,7 +153,8 @@ class OpenApi3BuilderTest : StringSpec() {
             api.openapi shouldBe "3.0.0"
             api.info.title shouldBe "jjjj"
             api.info.version shouldBe "1.0"
-            val securityScheme = api.components.securitySchemes["foo"]
+            val securityScheme =
+                    api.components.securitySchemes[SecurityScheme.Type.OPENIDCONNECT.toString()]
             securityScheme shouldNotBe null
             securityScheme!!.flows!!.implicit shouldNotBe null
             securityScheme.flows.implicit!!.extensions!!["x-internal"] shouldBe true
@@ -168,7 +175,19 @@ class OpenApi3BuilderTest : StringSpec() {
             findSchema<String>() shouldBe StringSchema()
             findSchema<Int>() shouldBe IntegerSchema()
             findSchema<Boolean>() shouldBe BooleanSchema()
+            findSchema<Long>() shouldBe IntegerSchema().format("int64")
+            findSchema<BigDecimal>() shouldBe IntegerSchema().format("")
+            findSchema<Date>() shouldBe DateSchema()
+            findSchema<LocalDate>() shouldBe DateSchema()
+            findSchema<LocalDateTime>() shouldBe DateTimeSchema()
             findSchema<ExampleRequestSchema>()?.javaClass shouldBe Schema<ExampleRequestSchema>().javaClass
+        }
+
+        "findSchema should return a valid schema for an enum" {
+            val schema = findSchema<ExampleEnum>()
+            schema shouldNotBe null
+            schema?.type shouldBe "string"
+            schema?.enum shouldBe listOf("ONE", "TWO")
         }
 
         "findSchema should return a valid schema for a list" {


### PR DESCRIPTION
I have been trying to validate swagger generated by this code by using https://editor.swagger.io. It won't validate if the SecuritySchemes has a "name" section. So I "removed" that from the dsl.

I have also had trouble with built-in classes (Long, Date etc.). ModelConverters.getInstance().read(T::class.java)[T::class.java.simpleName] returns null for them and so nothing gets written to the swagger and again it won't validate.

I also added code to handle enum schemas.